### PR TITLE
Tar høgde for scenariet der korrelasjonsid er deklarert, men ikkje definert, og lager i det tilfellet heller ein ny korrelasjonsid

### DIFF
--- a/src/main/java/no/skatteetaten/aurora/mvc/AuroraHeaderRestTemplateCustomizer.java
+++ b/src/main/java/no/skatteetaten/aurora/mvc/AuroraHeaderRestTemplateCustomizer.java
@@ -32,11 +32,15 @@ public class AuroraHeaderRestTemplateCustomizer implements RestTemplateCustomize
     }
 
     protected void addCorrelationId(HttpRequest request) {
-        String korrelasjonsid = Optional.ofNullable(BaggageField.getByName(KORRELASJONSID_FIELD))
+        String korrelasjonsid = Optional.ofNullable(getBaggageField())
             .map(BaggageField::getValue)
             .orElseGet(() -> UUID.randomUUID().toString());
 
         request.getHeaders().addIfAbsent(KORRELASJONSID_FIELD, korrelasjonsid);
+    }
+
+    BaggageField getBaggageField() {
+        return BaggageField.getByName(KORRELASJONSID_FIELD);
     }
 
     protected void addClientId(HttpRequest request) {

--- a/src/main/java/no/skatteetaten/aurora/mvc/AuroraHeaderRestTemplateCustomizer.java
+++ b/src/main/java/no/skatteetaten/aurora/mvc/AuroraHeaderRestTemplateCustomizer.java
@@ -4,6 +4,7 @@ import static no.skatteetaten.aurora.mvc.AuroraRequestParser.KLIENTID_FIELD;
 import static no.skatteetaten.aurora.mvc.AuroraRequestParser.KORRELASJONSID_FIELD;
 import static no.skatteetaten.aurora.mvc.AuroraRequestParser.MELDINGSID_FIELD;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.boot.web.client.RestTemplateCustomizer;
@@ -31,13 +32,9 @@ public class AuroraHeaderRestTemplateCustomizer implements RestTemplateCustomize
     }
 
     protected void addCorrelationId(HttpRequest request) {
-        BaggageField field = BaggageField.getByName(KORRELASJONSID_FIELD);
-        String korrelasjonsid;
-        if (field == null) {
-            korrelasjonsid = UUID.randomUUID().toString();
-        } else {
-            korrelasjonsid = field.getValue();
-        }
+        String korrelasjonsid = Optional.ofNullable(BaggageField.getByName(KORRELASJONSID_FIELD))
+            .map(BaggageField::getValue)
+            .orElseGet(() -> UUID.randomUUID().toString());
 
         request.getHeaders().addIfAbsent(KORRELASJONSID_FIELD, korrelasjonsid);
     }

--- a/src/test/kotlin/no/skatteetaten/aurora/mvc/AuroraHeaderRestTemplateCustomizerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/mvc/AuroraHeaderRestTemplateCustomizerTest.kt
@@ -1,0 +1,24 @@
+package no.skatteetaten.aurora.mvc
+
+import java.net.URI
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.client.ClientHttpRequestFactorySupplier
+import org.springframework.http.HttpMethod
+import assertk.assertThat
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import brave.baggage.BaggageField
+
+class AuroraHeaderRestTemplateCustomizerTest {
+    @Test
+    fun `If KorrelasjonsId is declared, but not instansiated, give it a new value`() {
+        val request = ClientHttpRequestFactorySupplier().get().createRequest(URI("http://localhost"), HttpMethod.GET)
+        val auroraHeaderRestTemplateCustomizer = object : AuroraHeaderRestTemplateCustomizer("test") {
+            override fun getBaggageField(): BaggageField {
+                return BaggageField.create(AuroraRequestParser.KORRELASJONSID_FIELD)
+            }
+        }
+        auroraHeaderRestTemplateCustomizer.addCorrelationId(request)
+        assertThat(request.headers[AuroraRequestParser.KORRELASJONSID_FIELD]!![0]).isNotNull().isNotEmpty()
+    }
+}


### PR DESCRIPTION
Når BaggageField for korrelasjonsid er deklarert, men ikkje gitt verdi, vil _addCorrelationId_ i dagens implementasjon setje korrelasjonsid i header på requesten til null.

Når vi i vårt system (Refusjon av kildeskatt på aksjeutbytte) prøver å oppgradere, får vi da trøbbel med nettopp dette. Derfor denne endringa, som handterer denne situasjonen likt som for eit felt som ikkje er deklarert.